### PR TITLE
Fix message listener return logic

### DIFF
--- a/content.js
+++ b/content.js
@@ -16,5 +16,5 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const outline = createOutline();
     sendResponse({ outline });
   }
-  return true;  // 非同期でsendResponseを呼び出すことを示すためにtrueを返す
+  // sendResponseを同期的に呼び出しているため、trueを返す必要はない
 });


### PR DESCRIPTION
## Summary
- remove unconditional `return true` from the content script
- add comment explaining that synchronous `sendResponse` doesn't require returning `true`

## Testing
- `node -c content.js`
- `node -c popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68447d31acb083248eede87f45749d32